### PR TITLE
AWS SSM agent is also pre-installed on Linux and macOS images

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Cloud service providers install proprietary software on customers virtual machin
 * Attack surface: 
   * Runs at high privileges
 * Open source: https://github.com/aws/amazon-ssm-agent
-* Operating system: Windows
+* Operating system: Windows, Linux, macOS
 
 ### AWS PV Drivers
 


### PR DESCRIPTION
As per [AWS docs](https://docs.aws.amazon.com/systems-manager/latest/userguide/ami-preinstalled-agent.html) the SSM agent is pre-installed on Linux and macOS in addition to Windows.